### PR TITLE
Fix for failing test QueryPhaseTests#testMinScoreDisablesCountOptimization

### DIFF
--- a/server/src/main/java/org/opensearch/common/lucene/MinimumScoreCollector.java
+++ b/server/src/main/java/org/opensearch/common/lucene/MinimumScoreCollector.java
@@ -40,6 +40,7 @@ import org.apache.lucene.search.LeafCollector;
 import org.apache.lucene.search.Scorable;
 import org.apache.lucene.search.ScoreCachingWrappingScorer;
 import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
 
 import java.io.IOException;
 
@@ -79,6 +80,11 @@ public class MinimumScoreCollector extends FilterCollector {
                 }
             }
         });
+    }
+
+    @Override
+    public void setWeight(Weight weight) {
+        // Not redirecting to delegate collector to maintain same behaviour when this extended SimpleCollector.
     }
 
     @Override


### PR DESCRIPTION
Fix for `QueryPhaseTests#testMinScoreDisablesCountOptimization` 
```
./gradlew :server:test --tests "org.opensearch.search.query.QueryPhaseTests.testMinScoreDisablesCountOptimization"
```
Failing Assertion for above test is as follows
```
  2> REPRODUCE WITH: ./gradlew ':server:test' --tests "org.opensearch.search.query.QueryPhaseTests" -Dtests.method="testMinScoreDisablesCountOptimization {p0=5 p1=org.opensearch.search.query.ConcurrentQueryPhaseSearcher@1dc2c13c}" -Dtests.seed=E00F2BA4B1B38BC3 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=ru -Dtests.timezone=Antarctica/Syowa -Druntime.java=23
  2> java.lang.AssertionError: expected:<0> but was:<1>
        at __randomizedtesting.SeedInfo.seed([E00F2BA4B1B38BC3:A95F97F3889D1273]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.junit.Assert.assertEquals(Assert.java:633)
        at org.opensearch.search.query.QueryPhaseTests.testMinScoreDisablesCountOptimization(QueryPhaseTests.java:333)
```
MinimumScoreCollector will extend FilterCollector instead of SimpleCollector from OpenSearch 3.0 

Any call to`setWeight` on MinimumScoreCollector was a no-op before ( default implementation in Collector interface ) 

With FilterCollector, it sets the weight on the delegate collector ( TotalHitCountCollector ) 

This causes a `CollectionTerminatedException` when `getLeafCollector` is called on the collector chain starting [here](https://github.com/reta/OpenSearch/blob/issue-11415/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java#L331)

```
(MinimumScoreCollector) -----> (FilterCollector) ---called as delegate---> (EarlyTerminatingCollector) -----> (FilterCollector) ---called as delegate---> (TotalHitCountCollector)
```

A quick solution is to take it back to old behaviour by overriding `setWeight` to no-op in `MinimumScoreCollector` 