### PR TITLE
Fixed unit tests for lucene 10 upgrade

### DIFF
--- a/server/src/main/java/org/opensearch/search/aggregations/MultiBucketCollector.java
+++ b/server/src/main/java/org/opensearch/search/aggregations/MultiBucketCollector.java
@@ -194,7 +194,7 @@ public class MultiBucketCollector extends BucketCollector {
         @Override
         public void setScorer(Scorable scorer) throws IOException {
             scoreCachingWrappingScorer = new ScoreCachingWrappingScorer(scorer);
-            super.setScorer(scoreCachingWrappingScorer);
+            in.setScorer(scoreCachingWrappingScorer);
         }
 
         @Override

--- a/server/src/test/java/org/opensearch/index/engine/CompletionStatsCacheTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/CompletionStatsCacheTests.java
@@ -39,7 +39,7 @@ import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.QueryCachingPolicy;
-import org.apache.lucene.search.suggest.document.Completion912PostingsFormat;
+import org.apache.lucene.search.suggest.document.Completion101PostingsFormat;
 import org.apache.lucene.search.suggest.document.SuggestField;
 import org.apache.lucene.store.Directory;
 import org.opensearch.OpenSearchException;
@@ -69,7 +69,7 @@ public class CompletionStatsCacheTests extends OpenSearchTestCase {
 
     public void testCompletionStatsCache() throws IOException, InterruptedException {
         final IndexWriterConfig indexWriterConfig = newIndexWriterConfig();
-        final PostingsFormat postingsFormat = new Completion912PostingsFormat();
+        final PostingsFormat postingsFormat = new Completion101PostingsFormat();
         indexWriterConfig.setCodec(new Lucene101Codec() {
             @Override
             public PostingsFormat getPostingsFormatForField(String field) {


### PR DESCRIPTION
For `MultiBucketCollectorTests` delegation in wrapping collector was changed. 

For `CompletionStatsCacheTests` new postings format was used. 


```
./gradlew :server:test --tests "org.opensearch.search.aggregations.MultiBucketCollectorTests.testSetScorerAfterCollectionTerminated"

./gradlew :server:test --tests "org.opensearch.index.engine.CompletionStatsCacheTests.testCompletionStatsCache"
```

@reta @msfroh Please have a look 