### PR TITLE
Fixed CategoryContextMappingTests and ContextIndexSearcherTests

### DIFF
--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -479,7 +479,6 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         );
         int seen = 0;
         checkCancelled.run();
-        iterator.advance(minDocId);
         for (int docId = iterator.nextDoc(); docId < maxDocId; docId = iterator.nextDoc()) {
             if (++seen % CHECK_CANCELLED_SCORER_INTERVAL == 0) {
                 checkCancelled.run();

--- a/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/opensearch/search/internal/ContextIndexSearcher.java
@@ -479,7 +479,8 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
         );
         int seen = 0;
         checkCancelled.run();
-        for (int docId = iterator.nextDoc(); docId < maxDocId; docId = iterator.nextDoc()) {
+        iterator.advance(minDocId);
+        for (int docId = iterator.docID(); docId < maxDocId; docId = iterator.nextDoc()) {
             if (++seen % CHECK_CANCELLED_SCORER_INTERVAL == 0) {
                 checkCancelled.run();
             }

--- a/server/src/test/java/org/opensearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/opensearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -799,7 +799,9 @@ public class CategoryContextMappingTests extends OpenSearchSingleNodeTestCase {
         ParseContext.Document document = new ParseContext.Document();
 
         KeywordFieldMapper.KeywordFieldType keyword = new KeywordFieldMapper.KeywordFieldType("category");
-        document.add(new KeywordFieldMapper.KeywordField(keyword.name(), new BytesRef("category1"), new FieldType()));
+        FieldType keywordFieldType = new FieldType();
+        keywordFieldType.setStored(true);
+        document.add(new KeywordFieldMapper.KeywordField(keyword.name(), new BytesRef("category1"), keywordFieldType));
         // Ignore doc values
         document.add(new SortedSetDocValuesField(keyword.name(), new BytesRef("category1")));
         Set<String> context = mapping.parseContext(document);


### PR DESCRIPTION
We were performing an extra call to DISI using advance which was causing `nextDoc` to return `no_more_docs` thus failing assertions which were looking for terms that should exist 
```
./gradlew :server:test --tests "org.opensearch.search.internal.ContextIndexSearcherTests.*"
```

Failure
```
java.lang.AssertionError: 
Expected :1
Actual   :0
<Click to see difference>

    at __randomizedtesting.SeedInfo.seed([D330CBAD18B4C179:7EB83697CB8AF665]:0)
    at org.junit.Assert.fail(Assert.java:89)
    at org.junit.Assert.failNotEquals(Assert.java:835)
    at org.junit.Assert.assertEquals(Assert.java:647)
    at org.junit.Assert.assertEquals(Assert.java:633)
    at org.opensearch.search.internal.ContextIndexSearcherTests.doTestContextIndexSearcher(ContextIndexSearcherTests.java:300)
    at org.opensearch.search.internal.ContextIndexSearcherTests.testContextIndexSearcherSparseNoDeletions(ContextIndexSearcherTests.java:194)
```


Lucene 10 has stricter checks for fields added [here](https://github.com/apache/lucene/blame/branch_10_0/lucene/core/src/java/org/apache/lucene/document/Field.java#L215-L221) so made a field as `stored: true` for `CategoryContextMappingTests` 

```
./gradlew :server:test --tests "org.opensearch.search.suggest.completion.CategoryContextMappingTests.*"
```

Failure reason 

```
CategoryContextMappingTests > testParsingContextFromDocument FAILED
    java.lang.IllegalArgumentException: it doesn't make sense to have a field that is neither indexed, nor doc-valued, nor stored
        at __randomizedtesting.SeedInfo.seed([BA7E75F0A4270C52:CC46643CD6991A76]:0)
        at org.apache.lucene.document.Field.<init>(Field.java:219)
        at org.opensearch.index.mapper.KeywordFieldMapper$KeywordField.<init>(KeywordFieldMapper.java:117)
        at org.opensearch.search.suggest.completion.CategoryContextMappingTests.testParsingContextFromDocument(CategoryContextMappingTests.java:804)
```