### PR TITLE
Fix for InternalEngineTests#testMergeSegmentsOnCommitDefault

### DIFF
--- a/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/opensearch/index/engine/InternalEngineTests.java
@@ -724,12 +724,19 @@ public class InternalEngineTests extends EngineTestCase {
             segments = engine.segments(true);
             assertThat(segments.size(), equalTo(1));
 
-            ParsedDocument doc2 = testParsedDocument("2", null, testDocumentWithTextField(), B_2, null);
-            engine.index(indexForDoc(doc2));
-            engine.refresh("test");
-            ParsedDocument doc3 = testParsedDocument("3", null, testDocumentWithTextField(), B_3, null);
-            engine.index(indexForDoc(doc3));
-            engine.refresh("test");
+            // Fails for [2,3] in Lucene 10 due to changes in TieredMergePolicy https://github.com/apache/lucene/pull/266
+            // causing 3 documents to be merged within one segment.
+            for (int i = 2; i <= 4; i++) {
+                ParsedDocument document = testParsedDocument(
+                    String.valueOf(i),
+                    null,
+                    testDocumentWithTextField(),
+                    new BytesArray(new byte[] { (byte) i }),
+                    null
+                );
+                engine.index(indexForDoc(document));
+                engine.refresh("test");
+            }
 
             segments = engine.segments(true);
             assertThat(segments.size(), equalTo(2));


### PR DESCRIPTION
```
./gradlew :server:test --tests "org.opensearch.index.engine.InternalEngineTests.*"
```


Test failure reason 

Assertion failing on number of segments expected after indexing three similar documents. 

```
> Task :server:test

REPRODUCE WITH: ./gradlew ':server:test' --tests "org.opensearch.index.engine.InternalEngineTests.testMergeSegmentsOnCommitDefault" -Dtests.seed=A664C8BCD8D6E7BA -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=en-PW -Dtests.timezone=Asia/Baku -Druntime.java=23

InternalEngineTests > testMergeSegmentsOnCommitDefault FAILED
    java.lang.AssertionError:
    Expected: <2>
         but: was <1>
        at __randomizedtesting.SeedInfo.seed([A664C8BCD8D6E7BA:2A696132A8617D3E]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.junit.Assert.assertThat(Assert.java:964)
        at org.junit.Assert.assertThat(Assert.java:930)
        at org.opensearch.index.engine.InternalEngineTests.testMergeSegmentsOnCommitDefault(InternalEngineTests.java:735)
```

The reason for failure is an [optimisation introduced in Lucene 10](https://github.com/apache/lucene/pull/266) that fits more docs into a single segment sooner. 

To make the test pass I have increased the number of docs being indexed before asserting for 2 segments. 

@reta Does it align with your [initial intention](https://github.com/opensearch-project/OpenSearch/pull/3561) of adding this test here ? 

Looks like it was focused towards testing the behavior of `setSegmentsPerTier` 