### PR TITLE
Updated to use modern Romanian Unicode

### DIFF
--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/20_analyzers.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/20_analyzers.yml
@@ -948,7 +948,7 @@
             text:     absenţa
             analyzer: romanian
     - length: { tokens: 1 }
-    - match:  { tokens.0.token: absenţ }
+    - match:  { tokens.0.token: absenț }
 
     - do:
         indices.analyze:
@@ -957,7 +957,7 @@
             text:     absenţa
             analyzer: my_analyzer
     - length: { tokens: 1 }
-    - match:  { tokens.0.token: absenţ }
+    - match:  { tokens.0.token: absenț }
 
 ---
 "russian":


### PR DESCRIPTION
Updating to use modern Romanian Unicode as per https://github.com/apache/lucene/pull/13233

```
> Task :modules:analysis-common:yamlRestTest

REPRODUCE WITH: ./gradlew ':modules:analysis-common:yamlRestTest' --tests "org.opensearch.analysis.common.CommonAnalysisClientYamlTestSuiteIT.test {yaml=analysis-common/20_analyzers/romanian}" -Dtests.seed=97D676B50D8CFDF2 -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1 -XX:ReservedCodeCacheSize=64m" -Dtests.locale=ky-Cyrl-KG -Dtests.timezone=Europe/Istanbul -Druntime.java=21
```

```
CommonAnalysisClientYamlTestSuiteIT > test {yaml=analysis-common/20_analyzers/romanian} FAILED
    java.lang.AssertionError: Failure at [analysis-common/20_analyzers:951]: tokens.0.token didn't match expected value:
                    tokens.0.token: expected String [absenţ] but was String [absenț]
        at __randomizedtesting.SeedInfo.seed([97D676B50D8CFDF2:1F82496FA370900A]:0)
        at org.opensearch.test.rest.yaml.OpenSearchClientYamlSuiteTestCase.executeSection(OpenSearchClientYamlSuiteTestCase.java:460)
        at org.opensearch.test.rest.yaml.OpenSearchClientYamlSuiteTestCase.test(OpenSearchClientYamlSuiteTestCase.java:433)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1750)
```